### PR TITLE
Use static functions instead of Shared instance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ TinyConsoleController(rootViewController: MyMainViewController())
 ### Actions
 
 ```swift
-TinyConsole.shared.print(text: "hello")
-TinyConsole.shared.addMarker()
-TinyConsole.shared.clear()
+TinyConsole.print("hello")
+TinyConsole.addMarker()
+TinyConsole.clear()
 ```
 
 ### Gestures

--- a/TinyConsole-Example/MainViewController.swift
+++ b/TinyConsole-Example/MainViewController.swift
@@ -40,19 +40,19 @@ class MainViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        TinyConsole.shared.print(text: "Tapped on \(indexPath.row)")
+        TinyConsole.print("Tapped on \(indexPath.row)")
     }
     
     func addLog() {
-        TinyConsole.shared.print(text: "hello world")
+        TinyConsole.print("hello world")
     }
     
     func clear() {
-        TinyConsole.shared.clear()
+        TinyConsole.clear()
     }
     
     func addMarker() {
-        TinyConsole.shared.addMarker()
+        TinyConsole.addMarker()
     }
 }
 

--- a/TinyConsole/TinyConsole.swift
+++ b/TinyConsole/TinyConsole.swift
@@ -26,18 +26,18 @@ open class TinyConsole {
         return self.dateFormatter.string(from: Date())
     }
     
-    public func scrollToBottom() {
-        if let textView = self.textView, textView.bounds.height < textView.contentSize.height {
+    public static func scrollToBottom(){
+        if let textView = shared.textView, textView.bounds.height < textView.contentSize.height {
             textView.layoutManager.ensureLayout(for: textView.textContainer)
             let offset = CGPoint(x: 0, y: (textView.contentSize.height - textView.frame.size.height))
             textView.setContentOffset(offset, animated: true)
         }
     }
     
-    public func print(text: String, global: Bool = true) {
+    public static func print(_ text: String, global: Bool = true){
         DispatchQueue.main.async {
-            if let textView = self.textView {
-                textView.text.append(self.currentTimeStamp() + " " + text + "\n")
+            if let textView = shared.textView {
+                textView.text.append(shared.currentTimeStamp() + " " + text + "\n")
                 self.scrollToBottom()
             }
             if global {
@@ -46,14 +46,37 @@ open class TinyConsole {
         }
     }
     
-    public func clear() {
+    public static func clear(){
         DispatchQueue.main.async {
-            self.textView?.text = ""
-            self.scrollToBottom()
+            shared.textView?.text = ""
+            TinyConsole.scrollToBottom()
         }
     }
     
+    public static func addMarker(){
+        TinyConsole.print("-----------")
+    }
+}
+
+// deprecated functions
+extension TinyConsole {
+    @available(*,deprecated, message: "use static function TinyConsole.scrollToBottom() instead")
+    public func scrollToBottom() {
+        TinyConsole.scrollToBottom()
+    }
+    
+    @available(*,deprecated, message: "use static function TinyConsole.print(_:, global:) instead")
+    public func print(text: String, global: Bool = true){
+        TinyConsole.print(text, global: global)
+    }
+    
+    @available(*,deprecated, message: "use static function TinyConsole.clear() instead")
+    public func clear() {
+        TinyConsole.clear()
+    }
+    
+    @available(*, deprecated, message: "use static function TinyConsole.addMarker() instead")
     public func addMarker() {
-        self.print(text: "-----------")
+        TinyConsole.addMarker()
     }
 }

--- a/TinyConsole/TinyConsole.swift
+++ b/TinyConsole/TinyConsole.swift
@@ -46,14 +46,14 @@ open class TinyConsole {
         }
     }
     
-    public static func clear(){
+    public static func clear() {
         DispatchQueue.main.async {
             shared.textView?.text = ""
             TinyConsole.scrollToBottom()
         }
     }
     
-    public static func addMarker(){
+    public static func addMarker() {
         TinyConsole.print("-----------")
     }
 }
@@ -66,7 +66,7 @@ extension TinyConsole {
     }
     
     @available(*,deprecated, message: "use static function TinyConsole.print(_:, global:) instead")
-    public func print(text: String, global: Bool = true){
+    public func print(text: String, global: Bool = true) {
         TinyConsole.print(text, global: global)
     }
     

--- a/TinyConsole/TinyConsole.swift
+++ b/TinyConsole/TinyConsole.swift
@@ -38,7 +38,7 @@ open class TinyConsole {
         DispatchQueue.main.async {
             if let textView = shared.textView {
                 textView.text.append(shared.currentTimeStamp() + " " + text + "\n")
-                self.scrollToBottom()
+                TinyConsole.scrollToBottom()
             }
             if global {
                 Swift.print(text)

--- a/TinyConsole/TinyConsoleViewController.swift
+++ b/TinyConsole/TinyConsoleViewController.swift
@@ -55,7 +55,7 @@ class TinyConsoleViewController: UIViewController {
         let okAction = UIAlertAction(title: "Add log", style: UIAlertActionStyle.default) {
             (action: UIAlertAction) in
             if let text = alert.textFields?.first?.text, !text.isEmpty {
-                TinyConsole.shared.print(text: text)
+                TinyConsole.print(text)
             }
         }
         
@@ -85,7 +85,7 @@ class TinyConsoleViewController: UIViewController {
         
         let clearAction = UIAlertAction(title: "Clear", style: UIAlertActionStyle.destructive) {
             (action: UIAlertAction) in
-            TinyConsole.shared.clear()
+            TinyConsole.clear()
         }
         
         let cancelAction = UIAlertAction(title: "Cancel", style: UIAlertActionStyle.cancel, handler: nil)
@@ -98,7 +98,7 @@ class TinyConsoleViewController: UIViewController {
     }
     
     func addMarker(sender: UISwipeGestureRecognizer) {
-        TinyConsole.shared.addMarker()
+        TinyConsole.addMarker()
     }
 }
 


### PR DESCRIPTION
I think the usage of static functions instead of a shared instance would look a lot nicer in code. 

Instead of writing

`TinyConsole.shared.print(text : "")`

you could just write

`TinyConsole.print("")`.